### PR TITLE
Update runtime to 24.08

### DIFF
--- a/fyi.zoey.Boop-GTK.json
+++ b/fyi.zoey.Boop-GTK.json
@@ -1,7 +1,7 @@
 {
     "app-id": "fyi.zoey.Boop-GTK",
     "runtime": "org.freedesktop.Platform",
-    "runtime-version": "22.08",
+    "runtime-version": "24.08",
     "sdk": "org.freedesktop.Sdk",
     "sdk-extensions": [
         "org.freedesktop.Sdk.Extension.rust-stable"


### PR DESCRIPTION
The runtime should be updated quickly
- It's unsupported and insecure
- GNOME Software will flag the application as unsupported, hiding it from users